### PR TITLE
feat(workflow): add queued Modal orchestrator for PPIFlow pipeline

### DIFF
--- a/src/biomodals/workflow/ppiflow_workflow.py
+++ b/src/biomodals/workflow/ppiflow_workflow.py
@@ -1,30 +1,21 @@
-"""Task-queue orchestrator for PPIFlow-style multi-stage design workflows.
+"""PPIFlow-style Modal workflow orchestrator.
 
-This workflow coordinates deployed Modal functions from:
-
-- ``biomodals.app.design.ppiflow_app``
-- ``biomodals.app.fol d.flowpacker_app``
-- ``biomodals.app.design.ligandmpnn_app``
-- ``biomodals.app.bioinfo.rosetta_app``
-- ``biomodals.app.score.af3score_app``
-
-The orchestrator builds a dependency-aware queue and runs independent steps in
-parallel worker threads from the local entrypoint.
+Follows the staged workflow in Mingchenchen/PPIFlow while dispatching to already
+-deployed Biomodals app functions.
 """
 
 from __future__ import annotations
 
 import json
-import time
 from collections import deque
-from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 import modal
 
-DEFAULT_APP_NAMES = {
+APP_NAMES = {
     "ppiflow": "PPIFlow",
     "flowpacker": "FlowPacker",
     "ligandmpnn": "LigandMPNN",
@@ -34,61 +25,66 @@ DEFAULT_APP_NAMES = {
 
 
 @dataclass
-class WorkflowTask:
-    """One queued workflow step."""
+class TaskSpec:
+    """One DAG node in the orchestrator task queue."""
 
     task_id: str
     app_key: str
-    fn_name: str
+    function_name: str
     kwargs: dict[str, Any]
-    needs: set[str] = field(default_factory=set)
+    deps: set[str] = field(default_factory=set)
 
 
-def _lookup_function(task: WorkflowTask):
-    app_name = DEFAULT_APP_NAMES[task.app_key]
-    return modal.Function.lookup(app_name, task.fn_name)
+def _lookup_modal_function(app_key: str, function_name: str):
+    return modal.Function.lookup(APP_NAMES[app_key], function_name)
 
 
-def _run_task(task: WorkflowTask) -> tuple[str, Any]:
-    fn = _lookup_function(task)
-    print(f"🧬 starting task '{task.task_id}' via {DEFAULT_APP_NAMES[task.app_key]}.{task.fn_name}")
+def _run_remote_task(task: TaskSpec) -> tuple[str, Any]:
+    fn = _lookup_modal_function(task.app_key, task.function_name)
+    print(f"🧬 [{task.task_id}] start -> {APP_NAMES[task.app_key]}.{task.function_name}")
     result = fn.remote(**task.kwargs)
-    print(f"🧬 completed task '{task.task_id}'")
+    print(f"🧬 [{task.task_id}] done")
     return task.task_id, result
 
 
-def _schedule(tasks: list[WorkflowTask], max_workers: int = 4) -> dict[str, Any]:
-    by_id = {task.task_id: task for task in tasks}
-    remaining = {task.task_id: set(task.needs) for task in tasks}
-    ready = deque([task_id for task_id, deps in remaining.items() if not deps])
+def _run_task_queue(tasks: list[TaskSpec], max_workers: int) -> dict[str, Any]:
+    task_map = {task.task_id: task for task in tasks}
+    unmet_deps = {task.task_id: set(task.deps) for task in tasks}
+    ready = deque([task_id for task_id, deps in unmet_deps.items() if not deps])
 
     outputs: dict[str, Any] = {}
-    in_flight: dict[Any, str] = {}
+    running: dict[Future, str] = {}
 
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
-        while ready or in_flight:
-            while ready and len(in_flight) < max_workers:
+        while ready or running:
+            while ready and len(running) < max_workers:
                 task_id = ready.popleft()
-                fut = pool.submit(_run_task, by_id[task_id])
-                in_flight[fut] = task_id
+                fut = pool.submit(_run_remote_task, task_map[task_id])
+                running[fut] = task_id
 
-            done, _ = wait(in_flight.keys(), return_when=FIRST_COMPLETED)
-            for fut in done:
-                task_id = in_flight.pop(fut)
-                finished_task_id, result = fut.result()
-                outputs[finished_task_id] = result
+            completed_futures, _ = wait(running.keys(), return_when=FIRST_COMPLETED)
+            for fut in completed_futures:
+                done_task_id = running.pop(fut)
+                _, result = fut.result()
+                outputs[done_task_id] = result
 
-                for waiting_task_id, deps in remaining.items():
-                    if task_id in deps:
-                        deps.remove(task_id)
-                        if not deps and waiting_task_id not in outputs and waiting_task_id not in ready and waiting_task_id not in in_flight.values():
-                            ready.append(waiting_task_id)
+                for task_id, deps in unmet_deps.items():
+                    if done_task_id in deps:
+                        deps.remove(done_task_id)
+                        if not deps and task_id not in outputs and task_id not in ready:
+                            if task_id not in running.values():
+                                ready.append(task_id)
 
-    unresolved = {k: v for k, v in remaining.items() if v and k not in outputs}
+    unresolved = {task_id: deps for task_id, deps in unmet_deps.items() if deps}
     if unresolved:
-        raise RuntimeError(f"Unresolved workflow dependencies: {unresolved}")
-
+        raise RuntimeError(f"DAG has unresolved dependencies: {unresolved}")
     return outputs
+
+
+def _read_optional_bytes(path: str | None) -> bytes | None:
+    if not path:
+        return None
+    return Path(path).expanduser().resolve().read_bytes()
 
 
 app = modal.App("PPIFlowWorkflow")
@@ -96,89 +92,127 @@ app = modal.App("PPIFlowWorkflow")
 
 @app.local_entrypoint()
 def submit_ppiflow_workflow(
-    run_name: str,
+    ppiflow_run_name: str,
     ppiflow_args_json: str,
-    ligandmpnn_input_pdb: str,
-    flowpacker_input_pdb: str,
-    rosetta_input_pdb: str,
-    rosetta_script: str,
-    af3_paths_json: str,
+    run_flowpacker: bool = True,
+    run_ligandmpnn: bool = True,
+    run_rosetta: bool = False,
+    run_af3score: bool = True,
+    flowpacker_input_pdb: str | None = None,
+    ligandmpnn_input_pdb: str | None = None,
+    rosetta_run_id: str | None = None,
+    rosetta_num_cpu_per_pod: int = 1,
+    af3_input_files_json: str = "[]",
+    af3_paths_json: str = "{}",
     max_workers: int = 4,
 ) -> None:
-    """Execute a queued PPIFlow workflow.
+    """Run a PPIFlow-compatible staged workflow using deployed Modal functions.
 
     Args:
-        run_name: Stable workflow run identifier.
-        ppiflow_args_json: JSON payload compatible with ``PPIFlowArgs`` model.
-        ligandmpnn_input_pdb: Path to input pdb for LigandMPNN.
-        flowpacker_input_pdb: Path to input pdb for FlowPacker.
-        rosetta_input_pdb: Path to input pdb for Rosetta.
-        rosetta_script: Path to RosettaScript XML file.
-        af3_paths_json: JSON dict with ``run_root/inputs_dir/output_dir/failed_dir/metrics_csv``.
-        max_workers: Number of parallel local orchestration workers.
+        ppiflow_run_name: Name used for the PPIFlow backbone generation step.
+        ppiflow_args_json: JSON that can instantiate ``PPIFlowArgs`` for `ppiflow_run`.
+        run_flowpacker: Whether to run the FlowPacker packing stage.
+        run_ligandmpnn: Whether to run the LigandMPNN design stage.
+        run_rosetta: Whether to run Rosetta refinement stage.
+        run_af3score: Whether to run AF3Score postprocess stage.
+        flowpacker_input_pdb: Input PDB for FlowPacker.
+        ligandmpnn_input_pdb: Input PDB for LigandMPNN.
+        rosetta_run_id: Optional explicit Rosetta run id.
+        rosetta_num_cpu_per_pod: CPU parallelism passed to Rosetta run function.
+        af3_input_files_json: JSON list of AF3 input file names.
+        af3_paths_json: JSON dict of AF3 path bundle.
+        max_workers: Max local orchestration workers for independent stages.
     """
-    run_stamp = int(time.time())
-    ligand_bytes = Path(ligandmpnn_input_pdb).expanduser().resolve().read_bytes()
-    flowpacker_bytes = Path(flowpacker_input_pdb).expanduser().resolve().read_bytes()
-    ppiflow_args = json.loads(ppiflow_args_json)
+    ppiflow_args: dict[str, Any] = json.loads(ppiflow_args_json)
+    af3_input_files = json.loads(af3_input_files_json)
+    af3_paths = json.loads(af3_paths_json)
 
-    rosetta_run_id = f"{run_name}-{run_stamp}"
-
-    tasks = [
-        WorkflowTask(
+    tasks: list[TaskSpec] = [
+        TaskSpec(
             task_id="ppiflow_design",
             app_key="ppiflow",
-            fn_name="ppiflow_run",
-            kwargs={"args": ppiflow_args, "run_name": f"{run_name}-ppiflow"},
-        ),
-        WorkflowTask(
-            task_id="ligandmpnn_sequences",
-            app_key="ligandmpnn",
-            fn_name="ligandmpnn_run",
-            kwargs={
-                "run_name": f"{run_name}-ligandmpnn",
-                "script_mode": "run",
-                "struct_bytes": ligand_bytes,
-                "seeds": [0, 1, 2],
-                "cli_args": {"--verbose": True},
-            },
-            needs={"ppiflow_design"},
-        ),
-        WorkflowTask(
-            task_id="flowpacker_pack",
-            app_key="flowpacker",
-            fn_name="run_flowpacker",
-            kwargs={
-                "input_files": [(Path(flowpacker_input_pdb).name, flowpacker_bytes)],
-                "run_name": f"{run_name}-flowpacker",
-                "n_samples": 1,
-            },
-            needs={"ppiflow_design"},
-        ),
-        WorkflowTask(
-            task_id="rosetta_refine",
-            app_key="rosetta",
-            fn_name="run_rosetta",
-            kwargs={
-                "run_name": run_name,
-                "run_id": rosetta_run_id,
-                "num_cpu_per_pod": 1,
-            },
-            needs={"ppiflow_design"},
-        ),
-        WorkflowTask(
-            task_id="af3_score",
-            app_key="af3score",
-            fn_name="af3score_postprocess",
-            kwargs={
-                "input_files": [Path(flowpacker_input_pdb).name],
-                "paths": json.loads(af3_paths_json),
-            },
-            needs={"ligandmpnn_sequences", "flowpacker_pack", "rosetta_refine"},
-        ),
+            function_name="ppiflow_run",
+            kwargs={"args": ppiflow_args, "run_name": ppiflow_run_name},
+        )
     ]
 
-    results = _schedule(tasks=tasks, max_workers=max_workers)
-    print("🧬 Workflow completed. Task outputs:")
+    if run_ligandmpnn:
+        if ligandmpnn_input_pdb is None:
+            raise ValueError("`ligandmpnn_input_pdb` is required when run_ligandmpnn=True")
+        ligand_bytes = Path(ligandmpnn_input_pdb).expanduser().resolve().read_bytes()
+        tasks.append(
+            TaskSpec(
+                task_id="ligandmpnn_stage",
+                app_key="ligandmpnn",
+                function_name="ligandmpnn_run",
+                kwargs={
+                    "run_name": f"{ppiflow_run_name}-ligandmpnn",
+                    "script_mode": "run",
+                    "struct_bytes": ligand_bytes,
+                    "seeds": [0, 1, 2],
+                    "cli_args": {},
+                    "bias_aa_per_residue_bytes": None,
+                    "omit_aa_per_residue_bytes": None,
+                },
+                deps={"ppiflow_design"},
+            )
+        )
+
+    if run_flowpacker:
+        if flowpacker_input_pdb is None:
+            raise ValueError("`flowpacker_input_pdb` is required when run_flowpacker=True")
+        flowpacker_bytes = Path(flowpacker_input_pdb).expanduser().resolve().read_bytes()
+        tasks.append(
+            TaskSpec(
+                task_id="flowpacker_stage",
+                app_key="flowpacker",
+                function_name="run_flowpacker",
+                kwargs={
+                    "input_files": [(Path(flowpacker_input_pdb).name, flowpacker_bytes)],
+                    "run_name": f"{ppiflow_run_name}-flowpacker",
+                    "model_name": "cluster",
+                    "use_confidence": False,
+                    "n_samples": 1,
+                },
+                deps={"ppiflow_design"},
+            )
+        )
+
+    if run_rosetta:
+        tasks.append(
+            TaskSpec(
+                task_id="rosetta_stage",
+                app_key="rosetta",
+                function_name="run_rosetta",
+                kwargs={
+                    "run_name": ppiflow_run_name,
+                    "run_id": rosetta_run_id or f"{ppiflow_run_name}-rosetta",
+                    "num_cpu_per_pod": rosetta_num_cpu_per_pod,
+                },
+                deps={"ppiflow_design"},
+            )
+        )
+
+    if run_af3score:
+        deps = {"ppiflow_design"}
+        if run_ligandmpnn:
+            deps.add("ligandmpnn_stage")
+        if run_flowpacker:
+            deps.add("flowpacker_stage")
+        if run_rosetta:
+            deps.add("rosetta_stage")
+
+        tasks.append(
+            TaskSpec(
+                task_id="af3score_stage",
+                app_key="af3score",
+                function_name="af3score_postprocess",
+                kwargs={"input_files": af3_input_files, "paths": af3_paths},
+                deps=deps,
+            )
+        )
+
+    results = _run_task_queue(tasks=tasks, max_workers=max_workers)
+    print("🧬 workflow finished")
     for task_id, result in results.items():
-        print(f"  - {task_id}: {type(result).__name__}")
+        print(f"🧬 {task_id}: {type(result).__name__}")

--- a/src/biomodals/workflow/ppiflow_workflow.py
+++ b/src/biomodals/workflow/ppiflow_workflow.py
@@ -1,1625 +1,184 @@
-"""PPIFlow source repo: <https://github.com/zhuqianhui2-hash/PPIFlow>.
+"""Task-queue orchestrator for PPIFlow-style multi-stage design workflows.
 
-This file (`ppiflow_app.py`) is a **single Modal entrypoint** that routes to multiple upstream
-PPIFlow sampling scripts (binder / antibody / nanobody / monomer / partial-flow variants),
-while enforcing a **stable output layout** and **inference-safe config override**.
+This workflow coordinates deployed Modal functions from:
 
-## What this wrapper guarantees
+- ``biomodals.app.design.ppiflow_app``
+- ``biomodals.app.fol d.flowpacker_app``
+- ``biomodals.app.design.ligandmpnn_app``
+- ``biomodals.app.bioinfo.rosetta_app``
+- ``biomodals.app.score.af3score_app``
 
-- **One CLI** (`--task`) for multiple PPIFlow scripts in `/ppiflow/sample_*.py`.
-- **Role-based uploads**: local input files are uploaded with stable filenames (e.g. `binder_input.pdb`,
-  `antigen.pdb`, `framework.pdb`, `complex.pdb`, `motif.csv`) so the remote worker never guesses ordering.
-- **Forced outputs** (remote side):
-  - `--output_dir` is forced to `/runs/<task>/<run_name>/outputs`
-  - `--name` is forced to `<run_name>`
-- **Effective config** (remote side):
-  - If a `--config` is provided, an `effective_config.yaml` is written under the run directory with:
-    `model.use_deepspeed_evo_attention = False`
-  - This makes inference **portable** (does not require deepspeed/nvcc kernels).
-
-## Configuration
-
-### Primary flags (local entrypoint)
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--task` | `binder` | Task router. One of: `binder`, `antibody`, `nanobody`, `monomer`, `scaffolding`, `ab_partial_flow`, `nb_partial_flow`, `binder_partial_flow`, `mpnn_stage1`, `mpnn_stage2`. |
-| `--run-name` | `test1` | Unique run identifier. Controls output directory name and tarball name (`<task>.<run-name>.tar.gz`). |
-| `--out-dir` | `./ppiflow_outputs` | Local directory to write the returned run bundle (`.tar.gz`). |
-| `--model-weights` | **Required** | Local/remote path to a checkpoint. Remote resolves to `/models/<basename>` unless already under `/models/`. |
-| `--config` | `None` | YAML config path (absolute in container or repo-relative). If provided, it will be rewritten to `effective_config.yaml` with deepspeed evo attention disabled. |
-
-### Input file flags (local -> uploaded to Modal)
-
-| Task | Required local file flags | Uploaded filename on worker |
-|------|---------------------------|-----------------------------|
-| `binder` | `--binder-input-pdb` | `binder_input.pdb` |
-| `binder_partial_flow` | `--binder-input-pdb` | `binder_input.pdb` |
-| `antibody` / `nanobody` | `--ab-antigen-pdb`, `--ab-framework-pdb` | `antigen.pdb`, `framework.pdb` |
-| `ab_partial_flow` / `nb_partial_flow` | `--pf-complex-pdb` | `complex.pdb` |
-| `scaffolding` | `--scaffold-motif-csv` | `motif.csv` |
-| `monomer` | *(no file upload required)* | *(none)* |
-| `mpnn_stage1` | *(no local upload; uses existing run)* | *(none; reads `/runs/<mpnn_source_task>/<mpnn_source_run>/outputs/*.pdb`)* |
-| `mpnn_stage2` | *(no local upload; uses existing run)* | *(none; reads `/runs/<mpnn_source_task>/<mpnn_source_run>/outputs/*.pdb`)* |
-
-### Binder args (sample_binder.py)
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--binder-target-chain` | `B` | Target chain ID passed to `--target_chain`. |
-| `--binder-binder-chain` | `A` | Binder chain ID passed to `--binder_chain`. |
-| `--binder-specified-hotspots` | `None` | Hotspots string, e.g. `"B119,B141,B200"`. |
-| `--binder-samples-min-length` | `75` | Minimum binder length. |
-| `--binder-samples-max-length` | `76` | Maximum binder length. |
-| `--binder-samples-per-target` | `5` | Number of samples per target. |
-
-### Antibody / Nanobody args (sample_antibody_nanobody.py)
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--ab-antigen-chain` | `None` | **Required** for `antibody/nanobody`. Passed to `--antigen_chain`. |
-| `--ab-heavy-chain` | `None` | **Required** for `antibody/nanobody`. Passed to `--heavy_chain`. |
-| `--ab-light-chain` | `None` | Optional light chain. Passed to `--light_chain` when provided. |
-| `--ab-specified-hotspots` | `None` | Optional hotspot residues on antigen, e.g. `"A56,A58"`. |
-| `--ab-cdr-length` | `None` | Optional CDR length override (string format per upstream script). |
-| `--ab-samples-per-target` | `5` | Samples per target for antibody/nanobody. |
-
-### Monomer unconditional args (sample_monomer.py)
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--mono-length-subset` | `None` | **Required** for `monomer`. String list, e.g. `"[60, 80, 100]"`. |
-| `--mono-samples-num` | `5` | Number of unconditional samples. |
-
-### Scaffolding args (sample_monomer.py motif mode)
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--scaffold-motif-names` | `None` | Optional motif name filter passed as `--motif_names`. |
-| `--scaffold-samples-num` | `5` | Number of scaffolding samples. |
-
-### Partial flow antibody / nanobody args (sample_antibody_nanobody_partial.py)
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--pf-fixed-positions` | `None` | **Required**. Fixed positions string, e.g. `"H26,H27,H28,L50-63"`. |
-| `--pf-cdr-position` | `None` | **Required**. CDR ranges string, e.g. `"H26-32,H45-56,H97-113"`. |
-| `--pf-start-t` | `None` | **Required**. Partial flow start time (float). |
-| `--pf-samples-per-target` | `None` | **Required**. Samples per target. |
-| `--pf-retry-limit` | `10` | Passed as `--retry_Limit` (upstream spelling). |
-| `--pf-specified-hotspots` | `None` | Optional hotspots for partial flow. |
-| `--pf-antigen-chain` | `None` | **Required**. Passed to `--antigen_chain`. |
-| `--pf-heavy-chain` | `None` | **Required**. Passed to `--heavy_chain`. |
-| `--pf-light-chain` | `None` | Optional. Passed to `--light_chain` when provided. |
-
-### Partial flow binder args (sample_binder_partial.py)
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--bpf-target-chain` | `B` | Target chain passed to `--target_chain`. |
-| `--bpf-binder-chain` | `A` | Binder chain passed to `--binder_chain`. |
-| `--bpf-start-t` | `0.7` | Partial flow start time passed to `--start_t`. |
-
-### MPNN / ABMPNN tasks
-For a complete set of protein_mpnn CLI options that can be used, see <https://github.com/Mingchenchen/PPIFlow/blob/main/ProteinMPNN/README.md>.
-
-
-`mpnn_stage1` and `mpnn_stage2` both run sequence design on an existing backbone run:
-
-- Required source run flags: `--mpnn-source-task`, `--mpnn-source-run`
-- Input backbones come from: `/runs/<mpnn_source_task>/<mpnn_source_run>/outputs/*.pdb`
-- Model choice: `--mpnn-model-name` (use `abmpnn` to run ABMPNN weights from `/models/abmpnn.pt`)
-- Runtime controls: `--mpnn-batch-size` (default `1`), `--mpnn-seed` (default `0`)
-- Optional design constraints:
-  - `--mpnn-chain-list` (chains to design)
-  - `--mpnn-position-list` (CSV path for fixed positions; if omitted, design is unconstrained/full-chain)
-  - `--mpnn-omit-aas` (optional amino acids to omit, e.g. `C`)
-  - `--mpnn-use-soluble-model` (optional flag for ProteinMPNN soluble weights mode)
-
-Stage semantics in this wrapper:
-
-- `mpnn_stage1` (exploration): default `--mpnn-num-seq-per-target-stage1 8`, `--mpnn-temp-stage1 0.5`
-- `mpnn_stage2` (conservative refinement): default `--mpnn-num-seq-per-target-stage2 4`, `--mpnn-temp-stage2 0.1`
-
-Current behavior note:
-
-- `mpnn_stage2` currently does not consume AF3-filtered outputs automatically; it is a second MPNN pass with different sampling settings.
-
-## Environment variables (Modal)
-
-| Environment variable | Default | Description |
-|----------------------|---------|-------------|
-| `MODAL_APP` | `ppiflow` | Name of the Modal app. |
-| `GPU` | `L40S` | GPU type for the worker (e.g. `A10G`, `A100`, `L40S`). |
-| `TIMEOUT` | `36000` | Modal function timeout (seconds). |
-
-## Persistent volumes & paths
-
-- Models volume: `ppiflow-models` mounted at `/models`
-- Runs volume: `ppiflow-runs` mounted at `/ppiflow-runs`
-
-Expected checkpoint layout (one-time upload examples):
-  1) ppiflow
-  modal volume put ppiflow-models antibody.ckpt /antibody.ckpt
-  modal volume put ppiflow-models binder.ckpt /binder.ckpt
-  modal volume put ppiflow-models monomer.ckpt /monomer.ckpt
-  modal volume put ppiflow-models nanobody.ckpt /nanobody.ckpt  2) proteinmpnn
-  2) Upload ProteinMPNN weights to persistent Volume (one-time)
-  modal volume put ppiflow-models v_48_002.pt /proteinmpnn_v_48_002.pt
-  modal volume put ppiflow-models v_48_010.pt /proteinmpnn_v_48_010.pt
-  modal volume put ppiflow-models v_48_020.pt /proteinmpnn_v_48_020.pt
-  3) abmpnn weights
-  modal volume put ppiflow-models abmpnn.pt /abmpnn.pt
-
-## Outputs
-
-- Each run is stored under the runs volume at:
-  `/runs/<task>/<run_name>/`
-  with:
-  - `inputs/`  (uploaded inputs)
-  - `outputs/` (upstream script outputs; forced `--output_dir`)
-  - `effective_config.yaml` (if `--config` provided)
-  - `cmd.txt` (exact executed command)
-  - `stdout.log` (combined stdout/stderr)
-  - `artifacts/` (best-effort collected: metrics/config + any `.csv`)
-
-- The local CLI saves a `.tar.gz` bundle to:
-  `<out-dir>/<task>.<run-name>.tar.gz`
-
-## Typical usage
-
-  # Binder (de novo)
-  modal run ppiflow_app.py --task binder -- \
-    --binder-input-pdb ~/target.pdb \
-    --binder-target-chain B \
-    --binder-binder-chain A \
-    --binder-specified-hotspots "B119,B141,B200" \
-    --binder-samples-min-length 75 \
-    --binder-samples-max-length 76 \
-    --binder-samples-per-target 5 \
-    --config /ppiflow/configs/inference_binder.yaml \
-    --model-weights /models/binder.ckpt \
-    --run-name test1 \
-    --out-dir ./ppiflow_outputs
-
-  # Antibody partial flow
-  modal run ppiflow_app.py --task ab_partial_flow -- \
-    --pf-complex-pdb ~/complex.pdb \
-    --pf-fixed-positions "H26,H27,H28,L50-63" \
-    --pf-cdr-position "H26-32,H45-56,H97-113" \
-    --pf-start-t 0.8 \
-    --pf-samples-per-target 5 \
-    --pf-antigen-chain A \
-    --pf-heavy-chain H \
-    --pf-light-chain L \
-    --model-weights /models/antibody.ckpt \
-    --run-name abp1
-
-  # MPNN stage1 (exploration) on an existing binder run
-  modal run ppiflow_app.py --task mpnn_stage1 -- \
-    --mpnn-source-task binder \
-    --mpnn-source-run test1 \
-    --mpnn-model-name v_48_020 \
-    --mpnn-num-seq-per-target-stage1 8 \
-    --mpnn-temp-stage1 0.5 \
-    --run-name mpnn_test1\
-    --mpnn-batch-size 1 \
-    --mpnn-seed 0
-
-
-  # MPNN stage2 (conservative refinement) on the same source run
-  modal run ppiflow_app.py --task mpnn_stage2 -- \
-    --mpnn-source-task binder \
-    --mpnn-source-run test1 \
-    --mpnn-model-name v_48_020 \
-    --mpnn-num-seq-per-target-stage2 4 \
-    --mpnn-temp-stage2 0.1 \
-    --run-name test1 \
-    --mpnn-batch-size 1 \
-    --mpnn-seed 0
-
-  # ABMPNN with fixed framework positions (design only selected residues/chains)
-  modal run ppiflow_app.py --task mpnn_stage1 -- \
-    --mpnn-source-task nanobody \
-    --mpnn-source-run nb1 \
-    --mpnn-model-name abmpnn \
-    --mpnn-chain-list A \
-    --mpnn-position-list ./fixed_positions.csv \
-    --mpnn-num-seq-per-target-stage1 8 \
-    --mpnn-temp-stage1 0.5
-
-  # ABMPNN full design (no fixed positions file provided)
-  modal run ppiflow_app.py --task mpnn_stage1 -- \
-    --mpnn-source-task nanobody \
-    --mpnn-source-run nb1 \
-    --mpnn-model-name abmpnn \
-    --mpnn-num-seq-per-target-stage1 8 \
-    --mpnn-temp-stage1 0.5
-
+The orchestrator builds a dependency-aware queue and runs independent steps in
+parallel worker threads from the local entrypoint.
 """
-
-# TODO: reuse *_app modules for constructing the workflow
 
 from __future__ import annotations
 
-import csv
 import json
-import os
-import subprocess
-import sys
-import tarfile
-import tempfile
-from collections.abc import Iterable
-from io import StringIO
+import time
+from collections import deque
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from modal import App, Image, Volume
+import modal
 
-# -------------------------
-# Modal configs
-# -------------------------
-APP_NAME = os.environ.get("MODAL_APP", "ppiflow")
-GPU = os.environ.get("GPU", "L40S")  # e.g. A10G, A100, L40S
-TIMEOUT = int(os.environ.get("TIMEOUT", "36000"))
-
-# Persistent Volumes
-MODELS_VOL = Volume.from_name("ppiflow-models", create_if_missing=True)
-RUNS_VOL = Volume.from_name("ppiflow-runs", create_if_missing=True)
-
-MODELS_DIR = Path("/models")
-RUNS_DIR = Path("/ppiflow-runs")
-
-# -------------------------
-# Image definition
-# -------------------------
-PPIFLOW_REPO = (
-    "https://github.com/zhuqianhui2-hash/PPIFlow.git"  # updated at 2026-02-10-18:00
-)
-PPIFLOW_DIR = "/ppiflow"
-
-PYTORCH_CU121_INDEX = "https://download.pytorch.org/whl/cu121"
-PYG_WHL = "https://data.pyg.org/whl/torch-2.3.0+cu121.html"
-
-TORCH_PKGS = [
-    "torch==2.3.1+cu121",
-    "torchvision==0.18.1+cu121",
-    "torchaudio==2.3.1+cu121",
-]
-
-PYG_PKGS = [
-    "pyg-lib==0.4.0+pt23cu121",
-    "torch-scatter==2.1.2+pt23cu121",
-    "torch-sparse==0.6.18+pt23cu121",
-    "torch-cluster==1.6.3+pt23cu121",
-    "torch-spline-conv==1.2.2+pt23cu121",
-    "torch-geometric==2.6.1",
-]
-
-INFER_PKGS = [
-    "numpy==1.26.3",
-    "scipy==1.15.2",
-    "pandas==2.2.3",
-    "scikit-learn==1.2.2",
-    "pyyaml==6.0.2",
-    "omegaconf==2.3.0",
-    "hydra-core==1.3.2",
-    "hydra-submitit-launcher==1.2.0",
-    "submitit==1.5.3",
-    "tqdm==4.67.1",
-    "lightning==2.5.0.post0",
-    "pytorch-lightning==2.5.0.post0",
-    "torchmetrics==1.6.2",
-    "lightning-utilities==0.14.0",
-    "einops==0.8.1",
-    "dm-tree==0.1.6",
-    "optree==0.14.1",
-    "opt-einsum==3.4.0",
-    "opt-einsum-fx==0.1.4",
-    "e3nn==0.5.6",
-    "fair-esm==2.0.0",
-    "biopython==1.83",
-    "biotite==1.0.1",
-    "biotraj==1.2.2",
-    "gemmi==0.6.5",
-    "ihm==2.2",
-    "modelcif==0.7",
-    "tmtools==0.2.0",
-    "freesasa==2.2.1",
-    "mdtraj==1.10.3",
-    "requests==2.32.3",
-    "packaging==24.2",
-    "typing-extensions==4.12.2",
-    "protobuf==3.20.2",
-    "tensorboard==2.19.0",
-    "tensorboard-data-server==0.7.2",
-    "grpcio==1.72.1",
-    "gputil==1.4.0",
-    "gpustat==1.1.1",
-    "hjson==3.1.0",
-    "ninja==1.11.1.3",
-]
-
-runtime_image = (
-    Image.debian_slim(python_version="3.10")
-    .apt_install(
-        "git",
-        "curl",
-        "ca-certificates",
-        "build-essential",
-        "python3-dev",
-        "pkg-config",
-        "gfortran",
-        "libopenblas-dev",
-        "liblapack-dev",
-        "libhdf5-dev",
-        "libnetcdf-dev",
-        "zlib1g-dev",
-        "libbz2-dev",
-        "liblzma-dev",
-    )
-    .env({"PYTHONUNBUFFERED": "1", "PYTHONPATH": PPIFLOW_DIR})
-    .run_commands(
-        f"rm -rf {PPIFLOW_DIR} && git clone --depth 1 {PPIFLOW_REPO} {PPIFLOW_DIR}"
-    )
-    .pip_install(*TORCH_PKGS, extra_index_url=PYTORCH_CU121_INDEX)
-    .uv_pip_install(*PYG_PKGS, find_links=PYG_WHL)
-    .uv_pip_install(*INFER_PKGS)
-)
-
-app = App(APP_NAME)
-
-# -------------------------
-# Task routing (PPIFlow sampling scripts only)
-# -------------------------
-TASK_TO_SCRIPT: dict[str, str] = {
-    "binder": f"{PPIFLOW_DIR}/sample_binder.py",
-    "antibody": f"{PPIFLOW_DIR}/sample_antibody_nanobody.py",
-    "nanobody": f"{PPIFLOW_DIR}/sample_antibody_nanobody.py",
-    "monomer": f"{PPIFLOW_DIR}/sample_monomer.py",
-    "scaffolding": f"{PPIFLOW_DIR}/sample_monomer.py",
-    "ab_partial_flow": f"{PPIFLOW_DIR}/sample_antibody_nanobody_partial.py",
-    "nb_partial_flow": f"{PPIFLOW_DIR}/sample_antibody_nanobody_partial.py",
-    "binder_partial_flow": f"{PPIFLOW_DIR}/sample_binder_partial.py",
+DEFAULT_APP_NAMES = {
+    "ppiflow": "PPIFlow",
+    "flowpacker": "FlowPacker",
+    "ligandmpnn": "LigandMPNN",
+    "rosetta": "Rosetta",
+    "af3score": "AF3Score",
 }
 
-MPNN_TASKS = {"mpnn_stage1", "mpnn_stage2"}
 
+@dataclass
+class WorkflowTask:
+    """One queued workflow step."""
 
-# -------------------------
-# Helpers
-# -------------------------
-def _tar_dir(src_dir: Path, out_tar_gz: Path) -> None:
-    with tarfile.open(out_tar_gz, "w:gz") as tf:
-        tf.add(src_dir, arcname=src_dir.name)
+    task_id: str
+    app_key: str
+    fn_name: str
+    kwargs: dict[str, Any]
+    needs: set[str] = field(default_factory=set)
 
 
-def _iter_files(root: Path) -> Iterable[Path]:
-    for p in root.rglob("*"):
-        if p.is_file():
-            yield p
+def _lookup_function(task: WorkflowTask):
+    app_name = DEFAULT_APP_NAMES[task.app_key]
+    return modal.Function.lookup(app_name, task.fn_name)
 
 
-def _write_effective_config(src_config: Path, dst_config: Path) -> None:
-    import yaml
+def _run_task(task: WorkflowTask) -> tuple[str, Any]:
+    fn = _lookup_function(task)
+    print(f"🧬 starting task '{task.task_id}' via {DEFAULT_APP_NAMES[task.app_key]}.{task.fn_name}")
+    result = fn.remote(**task.kwargs)
+    print(f"🧬 completed task '{task.task_id}'")
+    return task.task_id, result
 
-    cfg = yaml.safe_load(src_config.read_text()) or {}
-    cfg.setdefault("model", {})
-    cfg["model"]["use_deepspeed_evo_attention"] = False
-    dst_config.write_text(yaml.safe_dump(cfg, sort_keys=False))
 
+def _schedule(tasks: list[WorkflowTask], max_workers: int = 4) -> dict[str, Any]:
+    by_id = {task.task_id: task for task in tasks}
+    remaining = {task.task_id: set(task.needs) for task in tasks}
+    ready = deque([task_id for task_id, deps in remaining.items() if not deps])
 
-def _collect_artifacts(run_dir: Path) -> None:
-    artifacts = run_dir / "artifacts"
-    artifacts.mkdir(parents=True, exist_ok=True)
+    outputs: dict[str, Any] = {}
+    in_flight: dict[Any, str] = {}
 
-    want_exact = {"metrics.csv", "config.yml", "config.yaml"}
-    for f in _iter_files(run_dir):
-        if f.name in want_exact:
-            dst = artifacts / f.name
-            if not dst.exists():
-                dst.write_bytes(f.read_bytes())
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        while ready or in_flight:
+            while ready and len(in_flight) < max_workers:
+                task_id = ready.popleft()
+                fut = pool.submit(_run_task, by_id[task_id])
+                in_flight[fut] = task_id
 
-    for f in _iter_files(run_dir):
-        if f.suffix.lower() == ".csv":
-            dst = artifacts / f.name
-            if not dst.exists():
-                dst.write_bytes(f.read_bytes())
+            done, _ = wait(in_flight.keys(), return_when=FIRST_COMPLETED)
+            for fut in done:
+                task_id = in_flight.pop(fut)
+                finished_task_id, result = fut.result()
+                outputs[finished_task_id] = result
 
+                for waiting_task_id, deps in remaining.items():
+                    if task_id in deps:
+                        deps.remove(task_id)
+                        if not deps and waiting_task_id not in outputs and waiting_task_id not in ready and waiting_task_id not in in_flight.values():
+                            ready.append(waiting_task_id)
 
-def _script_help_text(script: Path) -> str:
-    p = subprocess.run(  # noqa: S603
-        [sys.executable, str(script), "--help"],
-        check=False,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-    )
-    return p.stdout or ""
+    unresolved = {k: v for k, v in remaining.items() if v and k not in outputs}
+    if unresolved:
+        raise RuntimeError(f"Unresolved workflow dependencies: {unresolved}")
 
+    return outputs
 
-def _script_supports_flag(
-    script: Path, flag: str, help_text: str | None = None
-) -> bool:
-    txt = help_text if help_text is not None else _script_help_text(script)
-    return flag in txt
 
+app = modal.App("PPIFlowWorkflow")
 
-def _find_abmpnn_run_script() -> Path:
-    """Find ABMPNN/ProteinMPNN runnable script under /ppiflow/ProteinMPNN.
 
-    We try common names, then fallback to a glob search.
-    """
-    base = Path(PPIFLOW_DIR) / "ProteinMPNN"
-    candidates = [
-        base / "protein_mpnn_run.py",
-        base / "run.py",
-        base / "protein_mpnn_run_main.py",
-        Path(PPIFLOW_DIR) / "protein_mpnn_run.py",
-    ]
-    for p in candidates:
-        if p.exists():
-            return p
-
-    hits = sorted(base.rglob("*mpnn*run*.py"))
-    if hits:
-        return hits[0]
-
-    raise FileNotFoundError(
-        f"ABMPNN run script not found under {base}. "
-        "Expected something like ProteinMPNN/protein_mpnn_run.py"
-    )
-
-
-def _resolve_abmpnn_ckpt(user_path: str | None) -> Path:
-    if user_path:
-        p = Path(user_path)
-    else:
-        p = Path(PPIFLOW_DIR) / "ProteinMPNN" / "model_weights" / "abmpnn.pt"
-    if not p.exists():
-        raise FileNotFoundError(f"ABMPNN checkpoint not found: {p}")
-    return p
-
-
-def _write_csv(path: Path, rows: list[dict[str, Any]], fieldnames: list[str]) -> None:
-    buf = StringIO()
-    w = csv.DictWriter(buf, fieldnames=fieldnames)
-    w.writeheader()
-    for r in rows:
-        w.writerow(r)
-    path.write_text(buf.getvalue())
-
-
-def _expand_position_token(token: str) -> list[int]:
-    token = token.strip()
-    if not token:
-        return []
-    if "-" in token:
-        a, b = token.split("-", 1)
-        start = int(a.strip())
-        end = int(b.strip())
-        if end < start:
-            raise ValueError(f"Invalid range: {token}")
-        return list(range(start, end + 1))
-    return [int(token)]
-
-
-def _normalize_fixed_positions_csv_bytes(raw_csv: bytes) -> bytes:
-    """Accept user-friendly fixed-position syntax and convert to ProteinMPNN style.
-
-    Supported input for the second column (e.g. motif_index / fixed_positions):
-    - "1 2 3 10 11"
-    - "1-25,34-50,59-96,118-127"
-
-    Output second column is normalized to:
-    - "1 2 3 ... 127"
-    """
-    text = raw_csv.decode("utf-8-sig")
-    reader = csv.DictReader(StringIO(text))
-    if not reader.fieldnames:
-        raise ValueError("mpnn position CSV has no header")
-
-    fns = list(reader.fieldnames)
-    lower_map = {f.lower(): f for f in fns}
-    name_col = lower_map.get("pdb_name") or lower_map.get("pdb_id")
-    pos_col = lower_map.get("motif_index") or lower_map.get("fixed_positions")
-    if not name_col or not pos_col:
-        raise ValueError(
-            "mpnn position CSV must contain (pdb_name or pdb_id) and "
-            "(motif_index or fixed_positions) columns"
-        )
-
-    rows = list(reader)
-    if not rows:
-        raise ValueError("mpnn position CSV has no data rows")
-
-    out_rows: list[dict[str, str]] = []
-    for r in rows:
-        pdb_name = (r.get(name_col) or "").strip()
-        if not pdb_name:
-            raise ValueError(f"Empty pdb name in row: {r}")
-        raw = (r.get(pos_col) or "").strip()
-        if not raw:
-            out = ""
-        else:
-            pieces = [p.strip() for p in raw.split(",") if p.strip()]
-            values: list[int] = []
-            for p in pieces:
-                values.extend(_expand_position_token(p))
-            vals = sorted(set(values))
-            out = " ".join(str(v) for v in vals)
-        out_rows.append({"pdb_name": pdb_name, "motif_index": out})
-
-    buf = StringIO()
-    writer = csv.DictWriter(buf, fieldnames=["pdb_name", "motif_index"])
-    writer.writeheader()
-    writer.writerows(out_rows)
-    return buf.getvalue().encode("utf-8")
-
-
-def _chain_order_from_pdb(pdb_path: Path) -> list[str]:
-    order: list[str] = []
-    seen: set[str] = set()
-    with pdb_path.open("r", encoding="utf-8", errors="ignore") as f:
-        for line in f:
-            if not (line.startswith("ATOM") or line.startswith("HETATM")):
-                continue
-            if len(line) < 22:
-                continue
-            chain_id = line[21].strip()
-            if not chain_id or chain_id in seen:
-                continue
-            seen.add(chain_id)
-            order.append(chain_id)
-    return order
-
-
-def _rewrite_fixed_positions_for_proteinmpnn(
-    csv_path: Path, pdb_folder: Path, chain_list: str
-) -> None:
-    """Generate fixed-position CSV for ProteinMPNN.
-
-    Convert normalized CSV (single position list per pdb) into upstream legacy format
-    expected by ProteinMPNN helper script:
-      second column uses '-' to separate per-chain residue lists in pdb chain order.
-    """
-    designed_chains = [c for c in chain_list.split() if c]
-    if not designed_chains:
-        raise ValueError(
-            "--mpnn-chain-list is required when --mpnn-position-list is provided"
-        )
-    if len(designed_chains) != 1:
-        raise ValueError(
-            "Current fixed-position CSV format supports one designed chain. "
-            f"Got --mpnn-chain-list={chain_list!r}"
-        )
-
-    text = csv_path.read_text(encoding="utf-8-sig")
-    reader = csv.DictReader(StringIO(text))
-    if not reader.fieldnames:
-        raise ValueError("mpnn_fixed_positions.csv has no header")
-    rows = list(reader)
-    if not rows:
-        raise ValueError("mpnn_fixed_positions.csv has no data rows")
-
-    out_rows: list[dict[str, str]] = []
-    target_chain = designed_chains[0]
-    for row in rows:
-        pdb_name = (row.get("pdb_name") or row.get("pdb_id") or "").strip()
-        if not pdb_name:
-            raise ValueError(f"Empty pdb_name/pdb_id in row: {row}")
-        pos_raw = (row.get("motif_index") or row.get("fixed_positions") or "").strip()
-
-        pdb_file = pdb_folder / f"{pdb_name}.pdb"
-        if not pdb_file.exists():
-            raise FileNotFoundError(
-                f"PDB not found for fixed positions row: {pdb_file}"
-            )
-        chains = _chain_order_from_pdb(pdb_file)
-        if not chains:
-            raise ValueError(f"Could not detect chain order from: {pdb_file}")
-        if target_chain not in chains:
-            raise ValueError(
-                f"Chain {target_chain!r} not found in {pdb_file.name}; chains={chains}"
-            )
-
-        segments: list[str] = []
-        for ch in chains:
-            segments.append(pos_raw if ch == target_chain else "")
-        out_rows.append({"pdb_name": pdb_name, "motif_index": "-".join(segments)})
-
-    buf = StringIO()
-    writer = csv.DictWriter(buf, fieldnames=["pdb_name", "motif_index"])
-    writer.writeheader()
-    writer.writerows(out_rows)
-    csv_path.write_text(buf.getvalue(), encoding="utf-8")
-
-
-def _write_empty_fixed_positions_csv(csv_path: Path, pdb_folder: Path) -> None:
-    """Write a no-op fixed-positions CSV for upstream protein_mpnn_run.py compatibility.
-
-    This avoids its UnboundLocalError when --position_list is omitted.
-    """
-    rows: list[dict[str, str]] = []
-    for pdb in sorted(pdb_folder.glob("*.pdb")):
-        rows.append({"pdb_name": pdb.stem, "motif_index": ""})
-    if not rows:
-        raise FileNotFoundError(f"No .pdb found under: {pdb_folder}")
-
-    buf = StringIO()
-    writer = csv.DictWriter(buf, fieldnames=["pdb_name", "motif_index"])
-    writer.writeheader()
-    writer.writerows(rows)
-    csv_path.write_text(buf.getvalue(), encoding="utf-8")
-
-
-def _collect_pdbs_for_mpnn(src_outputs: Path) -> list[Path]:
-    pdbs = sorted(src_outputs.glob("*.pdb"))
-    if not pdbs:
-        raise FileNotFoundError(f"No .pdb found under: {src_outputs}")
-    return pdbs
-
-
-def _gather_mpnn_fastas(mpnn_out_root: Path) -> list[Path]:
-    # accept .fa / .fasta / .faa etc. under seqs/
-    hits: list[Path] = []
-    for pat in (
-        "seqs/*.fa",
-        "seqs/*.fasta",
-        "seqs/*.faa",
-        "seqs/*.fa.gz",
-        "seqs/*.fasta.gz",
-    ):
-        hits.extend(mpnn_out_root.rglob(pat))
-    return sorted(set(hits))
-
-
-def _detect_abmpnn_cli_flags(mpnn_script: Path) -> dict[str, str]:
-    ht = _script_help_text(mpnn_script)
-
-    # folder input (this is required for ProteinMPNN/protein_mpnn_run.py)
-    folder_flag = (
-        "--folder_with_pdbs_path"
-        if _script_supports_flag(mpnn_script, "--folder_with_pdbs_path", ht)
-        else ""
-    )
-    if not folder_flag and _script_supports_flag(mpnn_script, "--pdb_dir", ht):
-        folder_flag = "--pdb_dir"
-    if not folder_flag and _script_supports_flag(mpnn_script, "--input_folder", ht):
-        folder_flag = "--input_folder"
-
-    # single pdb input (optional, many scripts do NOT support it)
-    pdb_flag = (
-        "--pdb_path" if _script_supports_flag(mpnn_script, "--pdb_path", ht) else ""
-    )
-    if not pdb_flag and _script_supports_flag(mpnn_script, "--input_pdb", ht):
-        pdb_flag = "--input_pdb"
-
-    # out dir
-    out_flag = (
-        "--out_folder" if _script_supports_flag(mpnn_script, "--out_folder", ht) else ""
-    )
-    if not out_flag and _script_supports_flag(mpnn_script, "--output_dir", ht):
-        out_flag = "--output_dir"
-    if not out_flag and _script_supports_flag(mpnn_script, "--out_dir", ht):
-        out_flag = "--out_dir"
-
-    # checkpoint (ABMPNN single file OR ProteinMPNN model dir system)
-    ckpt_candidates = [
-        "--checkpoint_path",
-        "--checkpoint",
-        "--model_path",
-        "--weights",
-        "--ckpt",
-        "--checkpoint_file",
-    ]
-    ckpt_flag = ""
-    for f in ckpt_candidates:
-        if _script_supports_flag(mpnn_script, f, ht):
-            ckpt_flag = f
-            break
-
-    # ProteinMPNN classic interface (dir + model_name)
-    weights_dir_flag = (
-        "--path_to_model_weights"
-        if _script_supports_flag(mpnn_script, "--path_to_model_weights", ht)
-        else ""
-    )
-    model_name_flag = (
-        "--model_name" if _script_supports_flag(mpnn_script, "--model_name", ht) else ""
-    )
-
-    nseq_flag = (
-        "--num_seq_per_target"
-        if _script_supports_flag(mpnn_script, "--num_seq_per_target", ht)
-        else ""
-    )
-    if not nseq_flag and _script_supports_flag(mpnn_script, "--num_seqs", ht):
-        nseq_flag = "--num_seqs"
-
-    temp_flag = (
-        "--sampling_temp"
-        if _script_supports_flag(mpnn_script, "--sampling_temp", ht)
-        else ""
-    )
-    seed_flag = "--seed" if _script_supports_flag(mpnn_script, "--seed", ht) else ""
-    batch_flag = (
-        "--batch_size" if _script_supports_flag(mpnn_script, "--batch_size", ht) else ""
-    )
-
-    if not out_flag:
-        raise RuntimeError(
-            f"Cannot detect output flag for {mpnn_script}. "
-            "Expected one of: --out_folder / --output_dir / --out_dir"
-        )
-
-    # For protein_mpnn_run.py, folder_flag is required
-    if "protein_mpnn_run.py" in str(mpnn_script) and not folder_flag:
-        raise RuntimeError(
-            f"{mpnn_script} appears to require folder input, but folder flag not detected. "
-            "Expected --folder_with_pdbs_path."
-        )
-
-    return {
-        "folder_flag": folder_flag,
-        "pdb_flag": pdb_flag,
-        "out_flag": out_flag,
-        "ckpt_flag": ckpt_flag,
-        "weights_dir_flag": weights_dir_flag,
-        "model_name_flag": model_name_flag,
-        "nseq_flag": nseq_flag,
-        "temp_flag": temp_flag,
-        "seed_flag": seed_flag,
-        "batch_flag": batch_flag,
-    }
-
-
-def _run_abmpnn_on_folder(
-    *,
-    mpnn_script: Path,
-    flags: dict[str, str],
-    pdb_folder: Path,
-    out_folder: Path,
-    ckpt_path: Path | None,
-    num_seqs: int,
-    sampling_temp: float,
-    seed: int,
-    batch_size: int,
-    model_name: str | None,
-    chain_list: str | None,
-    position_list_csv: Path | None,
-    omit_aas: str | None,
-    use_soluble_model: bool,
-    log_path: Path,
-) -> None:
-    """Run ProteinMPNN / ABMPNN script in folder mode.
-
-    This is intentionally "no patch mode": execute upstream script as-is.
-    """
-    out_folder.mkdir(parents=True, exist_ok=True)
-
-    run_script = mpnn_script
-    patch_dir = mpnn_script.parent  # e.g. /ppiflow/ProteinMPNN
-
-    # -------------------------
-    # Step 1: build argv
-    # -------------------------
-    argv: list[str] = ["python", str(run_script)]
-
-    folder_flag = flags.get("folder_flag") or ""
-    pdb_flag = flags.get("pdb_flag") or ""
-    if folder_flag:
-        argv += [folder_flag, str(pdb_folder)]
-    elif pdb_flag:
-        raise RuntimeError(
-            "MPNN runner is configured for folder mode, but folder_flag is missing and pdb_flag exists. "
-            "Implement a single-PDB runner or ensure folder_flag is detected correctly."
-        )
-    else:
-        raise RuntimeError("Neither folder_flag nor pdb_flag detected for MPNN script.")
-
-    out_flag = flags.get("out_flag") or ""
-    if not out_flag:
-        raise RuntimeError("No out_flag detected for MPNN script.")
-    argv += [out_flag, str(out_folder)]
-
-    ckpt_flag = flags.get("ckpt_flag") or ""
-    if ckpt_flag:
-        if ckpt_path is None:
-            raise ValueError(
-                f"MPNN script expects {ckpt_flag}, but no checkpoint path was resolved."
-            )
-        argv += [ckpt_flag, str(ckpt_path)]
-    else:
-        weights_dir_flag = flags.get("weights_dir_flag") or ""
-        model_name_flag = flags.get("model_name_flag") or ""
-        if not weights_dir_flag or not model_name_flag:
-            raise RuntimeError(
-                "MPNN script does not expose a checkpoint flag and does not expose "
-                "--path_to_model_weights/--model_name. Cannot pass weights."
-            )
-        weights_dir = Path("/models")
-        argv += [weights_dir_flag, str(weights_dir)]
-
-        if not model_name:
-            raise ValueError(
-                "mpnn_model_name is required for this ProteinMPNN script (--model_name). "
-                "You passed None/empty."
-            )
-        argv += [model_name_flag, str(model_name)]
-
-        # --- sanity check for classic ProteinMPNN ---
-        expected_pt = weights_dir / f"{model_name}.pt"
-        if not expected_pt.exists():
-            available = sorted(p.name for p in weights_dir.glob("*.pt"))
-            raise FileNotFoundError(
-                f"ProteinMPNN weight not found: {expected_pt}\n"
-                f"Available under /models: {available}"
-            )
-        # --- auto-detect CA-only checkpoint and toggle --ca_only ---
-        try:
-            import torch
-
-            ckpt = torch.load(str(expected_pt), map_location="cpu")
-            sd = ckpt.get("model_state_dict", ckpt)
-            w = sd.get("features.edge_embedding.weight", None)
-            if w is not None and hasattr(w, "shape") and len(w.shape) == 2:
-                if int(w.shape[1]) == 167:
-                    argv += ["--ca_only"]
-        except Exception as e:
-            print(
-                f"Warning: failed to auto-detect CA-only checkpoint for {expected_pt}: {e}"
-            )
-
-    nseq_flag = flags.get("nseq_flag") or ""
-    temp_flag = flags.get("temp_flag") or ""
-    seed_flag = flags.get("seed_flag") or ""
-    batch_flag = flags.get("batch_flag") or ""
-
-    if nseq_flag:
-        argv += [nseq_flag, str(int(num_seqs))]
-    if temp_flag:
-        argv += [temp_flag, str(float(sampling_temp))]
-    if seed_flag:
-        argv += [seed_flag, str(int(seed))]
-    if batch_flag:
-        argv += [batch_flag, str(int(batch_size))]
-
-    if chain_list:
-        argv += ["--chain_list", chain_list]
-    if position_list_csv:
-        argv += ["--position_list", str(position_list_csv)]
-    if omit_aas:
-        argv += ["--omit_AAs", omit_aas]
-    if use_soluble_model:
-        argv += ["--use_soluble_model"]
-
-    # -------------------------
-    # Step 3: run with cwd = original ProteinMPNN dir to satisfy relative imports
-    # -------------------------
-    p = subprocess.run(  # noqa: S603
-        argv,
-        check=False,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        cwd=str(patch_dir),  # critical: make `protein_mpnn_utils` importable
-    )
-
-    dbg: list[str] = []
-    dbg.append("=== runner ===")
-    dbg.append(f"original_script: {mpnn_script}")
-    dbg.append(f"executed_script: {run_script}")
-    dbg.append(f"cwd: {patch_dir}")
-    dbg.append("")
-    dbg.append("=== argv ===")
-    dbg.append(" ".join(argv))
-    dbg.append("")
-    dbg.append("=== output ===")
-    dbg.append(p.stdout or "")
-    log_path.write_text("\n".join(dbg))
-
-    if p.returncode != 0:
-        raise RuntimeError(
-            f"ABMPNN/ProteinMPNN failed (exit {p.returncode}). See {log_path}"
-        )
-
-
-def _stage_pdb_folder(pdbs: list[Path], dst_dir: Path) -> None:
-    dst_dir.mkdir(parents=True, exist_ok=True)
-    for p in pdbs:
-        # keep stable filenames
-        (dst_dir / p.name).write_bytes(p.read_bytes())
-
-
-# -------------------------
-# Remote GPU job: unified runner
-# -------------------------
-@app.function(
-    gpu=GPU,
-    cpu=(2, 8),
-    timeout=TIMEOUT,
-    image=runtime_image,
-    volumes={str(MODELS_DIR): MODELS_VOL, str(RUNS_DIR): RUNS_VOL},
-)
-def run_ppiflow_structured(
-    # ---------- common ----------
-    task: str,
-    run_name: str,
-    input_files: list[tuple[str, bytes]],
-    model_weights: str | None,
-    config: str | None,
-    # ---------- binder (sample_binder.py) ----------
-    binder_target_chain: str,
-    binder_binder_chain: str,
-    binder_specified_hotspots: str | None,
-    binder_samples_min_length: int,
-    binder_samples_max_length: int,
-    binder_samples_per_target: int,
-    # ---------- antibody/nanobody (sample_antibody_nanobody.py) ----------
-    ab_antigen_chain: str | None,
-    ab_heavy_chain: str | None,
-    ab_light_chain: str | None,
-    ab_specified_hotspots: str | None,
-    ab_cdr_length: str | None,
-    ab_samples_per_target: int,
-    # ---------- monomer (sample_monomer.py unconditional) ----------
-    mono_length_subset: str | None,
-    mono_samples_num: int,
-    # ---------- scaffolding (sample_monomer.py motif) ----------
-    scaffold_motif_names: str | None,
-    scaffold_samples_num: int,
-    # ---------- partial flow antibody/nanobody ----------
-    pf_fixed_positions: str | None,
-    pf_cdr_position: str | None,
-    pf_specified_hotspots: str | None,
-    pf_start_t: float | None,
-    pf_samples_per_target: int | None,
-    pf_retry_limit: int,
-    pf_antigen_chain: str | None,
-    pf_heavy_chain: str | None,
-    pf_light_chain: str | None,
-    # ---------- partial flow binder ----------
-    bpf_target_chain: str,
-    bpf_binder_chain: str,
-    bpf_start_t: float,
-    # ---------- mpnn ----------
-    mpnn_source_task: str | None,
-    mpnn_source_run: str | None,
-    mpnn_num_seq_per_target_stage1: int,
-    mpnn_num_seq_per_target_stage2: int,
-    mpnn_temp_stage1: float,
-    mpnn_temp_stage2: float,
-    mpnn_model_name: str | None,
-    mpnn_batch_size: int,
-    mpnn_seed: int,
-    mpnn_ckpt_path: str | None,
-    mpnn_chain_list: str | None,
-    mpnn_omit_aas: str | None,
-    mpnn_use_soluble_model: bool,
-) -> bytes:
-    """Unified runner for PPIFlow structured sampling tasks."""
-    # -------------------------
-    # Branch 1: MPNN tasks (operate on existing run dir)
-    # -------------------------
-    if task in MPNN_TASKS:
-        if not mpnn_source_task or not mpnn_source_run:
-            raise ValueError(
-                "mpnn_stage1/2 requires --mpnn-source-task and --mpnn-source-run"
-            )
-
-        src_run_dir = RUNS_DIR / mpnn_source_task / mpnn_source_run
-        src_outputs = src_run_dir / "outputs"
-        if not src_outputs.exists():
-            raise FileNotFoundError(f"Source outputs missing: {src_outputs}")
-
-        pdbs = _collect_pdbs_for_mpnn(src_outputs)
-
-        mpnn_script = _find_abmpnn_run_script()
-
-        # detect flags first, then resolve checkpoint only when needed
-        flags = _detect_abmpnn_cli_flags(mpnn_script)
-        ckpt_path: Path | None = None
-        if flags.get("ckpt_flag"):
-            ckpt_path = _resolve_abmpnn_ckpt(mpnn_ckpt_path)
-        (src_run_dir / f"{task}.mpnn_help.txt").write_text(
-            _script_help_text(mpnn_script)
-        )
-
-        mpnn_dir = src_run_dir / task
-        mpnn_out = mpnn_dir / "out"
-        mpnn_dir.mkdir(parents=True, exist_ok=True)
-
-        if task == "mpnn_stage1":
-            num_seq = int(mpnn_num_seq_per_target_stage1)
-            temp = float(mpnn_temp_stage1)
-            manifest_name = "candidates_stage1.csv"
-        else:
-            num_seq = int(mpnn_num_seq_per_target_stage2)
-            temp = float(mpnn_temp_stage2)
-            manifest_name = "candidates_stage2.csv"
-
-        mpnn_out = mpnn_dir / "out"
-        pdb_folder = mpnn_dir / "pdbs"
-        mpnn_inputs = mpnn_dir / "inputs"
-        mpnn_dir.mkdir(parents=True, exist_ok=True)
-        mpnn_inputs.mkdir(parents=True, exist_ok=True)
-
-        _stage_pdb_folder(pdbs, pdb_folder)
-
-        position_list_csv: Path | None = None
-        for fname, content in input_files:
-            dst = mpnn_inputs / Path(fname).name
-            dst.write_bytes(content)
-            if Path(fname).name == "mpnn_fixed_positions.csv":
-                position_list_csv = dst
-        if position_list_csv and not mpnn_chain_list:
-            raise ValueError(
-                f"{task} requires --mpnn-chain-list when --mpnn-position-list is provided"
-            )
-        if position_list_csv:
-            _rewrite_fixed_positions_for_proteinmpnn(
-                csv_path=position_list_csv,
-                pdb_folder=pdb_folder,
-                chain_list=mpnn_chain_list or "",
-            )
-        else:
-            # Keep "full design" behavior while working around upstream UnboundLocalError.
-            position_list_csv = mpnn_inputs / "mpnn_fixed_positions.auto.csv"
-            _write_empty_fixed_positions_csv(position_list_csv, pdb_folder)
-
-        log_path = mpnn_dir / "mpnn_folder.log"
-        _run_abmpnn_on_folder(
-            mpnn_script=mpnn_script,
-            flags=flags,
-            pdb_folder=pdb_folder,
-            out_folder=mpnn_out,
-            ckpt_path=ckpt_path,
-            num_seqs=num_seq,
-            sampling_temp=temp,
-            seed=int(mpnn_seed),
-            batch_size=int(mpnn_batch_size),
-            model_name=mpnn_model_name,
-            chain_list=mpnn_chain_list,
-            position_list_csv=position_list_csv,
-            omit_aas=mpnn_omit_aas,
-            use_soluble_model=mpnn_use_soluble_model,
-            log_path=log_path,
-        )
-
-        fastas = _gather_mpnn_fastas(mpnn_out)
-        if not fastas:
-            raise RuntimeError(
-                f"No fasta outputs found under {mpnn_out} (expected */seqs/*.fa*)"
-            )
-
-        rows: list[dict[str, Any]] = []
-        for fa in fastas:
-            # .../out/<pdb_stem>/seqs/<something>.fa
-            try:
-                pdb_stem = fa.parent.parent.name
-            except Exception:
-                pdb_stem = fa.stem
-            rows.append(
-                {
-                    "pdb_path": str((src_outputs / f"{pdb_stem}.pdb").resolve()),
-                    "seq_fasta": str(fa.resolve()),
-                    "iptm": "",
-                    "ptm": "",
-                    "passed": "",
-                }
-            )
-
-        _write_csv(
-            src_run_dir / manifest_name,
-            rows,
-            ["pdb_path", "seq_fasta", "iptm", "ptm", "passed"],
-        )
-
-        (src_run_dir / f"{task}.meta.json").write_text(
-            json.dumps(
-                {
-                    "mpnn_script": str(mpnn_script),
-                    "ckpt_path": str(ckpt_path) if ckpt_path else None,
-                    "num_seq_per_target": num_seq,
-                    "sampling_temp": temp,
-                    "batch_size": int(mpnn_batch_size),
-                    "seed": int(mpnn_seed),
-                    "chain_list": mpnn_chain_list,
-                    "position_list_provided": bool(position_list_csv),
-                    "omit_aas": mpnn_omit_aas,
-                    "use_soluble_model": bool(mpnn_use_soluble_model),
-                    "detected_flags": flags,
-                },
-                indent=2,
-            )
-        )
-
-        RUNS_VOL.commit()
-
-        # Return a tar of the SOURCE run dir (so you get both backbone outputs and mpnn outputs)
-        with tempfile.TemporaryDirectory() as td:
-            tar_path = Path(td) / f"{task}.{run_name}.tar.gz"
-            _tar_dir(src_run_dir, tar_path)
-            return tar_path.read_bytes()
-
-    # -------------------------
-    # Branch 2: PPIFlow sampling tasks
-    # -------------------------
-    if task not in TASK_TO_SCRIPT:
-        raise ValueError(
-            f"Unknown task={task}. Choose from {sorted(TASK_TO_SCRIPT) + sorted(MPNN_TASKS)}"
-        )
-
-    script = Path(TASK_TO_SCRIPT[task])
-    if not script.exists():
-        raise FileNotFoundError(f"Script not found in image: {script}")
-
-    run_dir = RUNS_DIR / task / run_name
-    inputs_dir = run_dir / "inputs"
-    outputs_dir = run_dir / "outputs"
-    run_dir.mkdir(parents=True, exist_ok=True)
-    inputs_dir.mkdir(parents=True, exist_ok=True)
-    outputs_dir.mkdir(parents=True, exist_ok=True)
-
-    # ---- write inputs (role-based filenames) ----
-    for fname, content in input_files:
-        (inputs_dir / Path(fname).name).write_bytes(content)
-
-    # ---- resolve model checkpoint (required for sampling tasks) ----
-    if not model_weights:
-        raise ValueError("--model-weights is required for PPIFlow sampling tasks")
-    mw = Path(model_weights)
-    model_ckpt = mw if str(mw).startswith(str(MODELS_DIR)) else (MODELS_DIR / mw.name)
-    if not model_ckpt.exists():
-        raise FileNotFoundError(f"Model checkpoint not found: {model_ckpt}")
-
-    # ---- resolve config + write effective config (optional) ----
-    effective_config: Path | None = None
-    if config:
-        cfg_path = Path(config)
-        if not cfg_path.is_absolute():
-            cfg_guess = Path(PPIFLOW_DIR) / config
-            cfg_path = cfg_guess if cfg_guess.exists() else cfg_path
-        if not cfg_path.exists():
-            raise FileNotFoundError(
-                f"Config not found: {config} (resolved: {cfg_path})"
-            )
-        effective_config = run_dir / "effective_config.yaml"
-        _write_effective_config(cfg_path, effective_config)
-
-    def p_in(name: str) -> Path:
-        p = inputs_dir / name
-        if not p.exists():
-            raise FileNotFoundError(f"Required input file missing: {p}")
-        return p
-
-    argv: list[str] = ["python", str(script)]
-
-    if task == "binder":
-        input_pdb = p_in("binder_input.pdb")
-        argv += ["--input_pdb", str(input_pdb)]
-        argv += ["--target_chain", binder_target_chain]
-        argv += ["--binder_chain", binder_binder_chain]
-        if effective_config:
-            argv += ["--config", str(effective_config)]
-        if binder_specified_hotspots:
-            argv += ["--specified_hotspots", binder_specified_hotspots]
-        argv += [
-            "--samples_min_length",
-            str(binder_samples_min_length),
-            "--samples_max_length",
-            str(binder_samples_max_length),
-            "--samples_per_target",
-            str(binder_samples_per_target),
-            "--model_weights",
-            str(model_ckpt),
-            "--output_dir",
-            str(outputs_dir),
-            "--name",
-            run_name,
-        ]
-
-    elif task in {"antibody", "nanobody"}:
-        antigen_pdb = p_in("antigen.pdb")
-        framework_pdb = p_in("framework.pdb")
-        argv += [
-            "--antigen_pdb",
-            str(antigen_pdb),
-            "--framework_pdb",
-            str(framework_pdb),
-        ]
-
-        if not ab_antigen_chain:
-            raise ValueError("antibody/nanobody requires --ab-antigen-chain")
-        if not ab_heavy_chain:
-            raise ValueError("antibody/nanobody requires --ab-heavy-chain")
-
-        argv += ["--antigen_chain", ab_antigen_chain, "--heavy_chain", ab_heavy_chain]
-        if ab_light_chain:
-            argv += ["--light_chain", ab_light_chain]
-        if ab_specified_hotspots:
-            argv += ["--specified_hotspots", ab_specified_hotspots]
-        if ab_cdr_length:
-            argv += ["--cdr_length", ab_cdr_length]
-        if effective_config:
-            argv += ["--config", str(effective_config)]
-        argv += [
-            "--samples_per_target",
-            str(ab_samples_per_target),
-            "--model_weights",
-            str(model_ckpt),
-            "--output_dir",
-            str(outputs_dir),
-            "--name",
-            run_name,
-        ]
-
-    elif task == "monomer":
-        if mono_length_subset is None:
-            raise ValueError("monomer requires --mono-length-subset")
-        if effective_config:
-            argv += ["--config", str(effective_config)]
-        argv += [
-            "--model_weights",
-            str(model_ckpt),
-            "--output_dir",
-            str(outputs_dir),
-            "--length_subset",
-            mono_length_subset,
-            "--samples_num",
-            str(mono_samples_num),
-        ]
-
-    elif task == "scaffolding":
-        motif_csv = p_in("motif.csv")
-        if effective_config:
-            argv += ["--config", str(effective_config)]
-        argv += [
-            "--model_weights",
-            str(model_ckpt),
-            "--output_dir",
-            str(outputs_dir),
-            "--motif_csv",
-            str(motif_csv),
-        ]
-        if scaffold_motif_names:
-            argv += ["--motif_names", scaffold_motif_names]
-        argv += ["--samples_num", str(scaffold_samples_num)]
-
-    elif task in {"ab_partial_flow", "nb_partial_flow"}:
-        complex_pdb = p_in("complex.pdb")
-
-        if not pf_fixed_positions:
-            raise ValueError(f"{task} requires --pf-fixed-positions")
-        if not pf_cdr_position:
-            raise ValueError(f"{task} requires --pf-cdr-position")
-        if pf_start_t is None:
-            raise ValueError(f"{task} requires --pf-start-t")
-        if pf_samples_per_target is None:
-            raise ValueError(f"{task} requires --pf-samples-per-target")
-        if not pf_antigen_chain:
-            raise ValueError(f"{task} requires --pf-antigen-chain")
-        if not pf_heavy_chain:
-            raise ValueError(f"{task} requires --pf-heavy-chain")
-
-        argv += [
-            "--complex_pdb",
-            str(complex_pdb),
-            "--fixed_positions",
-            pf_fixed_positions,
-            "--cdr_position",
-            pf_cdr_position,
-            "--start_t",
-            str(pf_start_t),
-            "--samples_per_target",
-            str(pf_samples_per_target),
-            "--output_dir",
-            str(outputs_dir),
-            "--retry_Limit",
-            str(pf_retry_limit),
-        ]
-        if pf_specified_hotspots:
-            argv += ["--specified_hotspots", pf_specified_hotspots]
-        if effective_config:
-            argv += ["--config", str(effective_config)]
-
-        argv += [
-            "--model_weights",
-            str(model_ckpt),
-            "--antigen_chain",
-            pf_antigen_chain,
-            "--heavy_chain",
-            pf_heavy_chain,
-        ]
-        if pf_light_chain:
-            argv += ["--light_chain", pf_light_chain]
-        argv += ["--name", run_name]
-
-    elif task == "binder_partial_flow":
-        input_pdb = p_in("binder_input.pdb")
-        argv += ["--input_pdb", str(input_pdb)]
-        if effective_config:
-            argv += ["--config", str(effective_config)]
-        argv += [
-            "--model_weights",
-            str(model_ckpt),
-            "--target_chain",
-            bpf_target_chain,
-            "--binder_chain",
-            bpf_binder_chain,
-            "--start_t",
-            str(bpf_start_t),
-            "--output_dir",
-            str(outputs_dir),
-        ]
-
-    else:
-        raise ValueError(f"Task routed but not implemented: {task}")
-
-    # ---- run ----
-    (run_dir / "cmd.txt").write_text(" ".join(argv) + "\n")
-    run_cwd = inputs_dir if task == "scaffolding" else None
-
-    p = subprocess.run(  # noqa: S603
-        argv,
-        check=False,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        cwd=str(run_cwd) if run_cwd else None,
-    )
-    (run_dir / "stdout.log").write_text(p.stdout or "")
-
-    # if fail, but outputs exist, keep; else raise
-    pdbs = sorted((run_dir / "outputs").glob("*.pdb"))
-    if p.returncode != 0 and not pdbs:
-        raise RuntimeError(
-            f"PPIFlow failed (exit {p.returncode}). See {run_dir}/stdout.log"
-        )
-
-    _collect_artifacts(run_dir)
-    RUNS_VOL.commit()
-
-    with tempfile.TemporaryDirectory() as td:
-        tar_path = Path(td) / f"{task}.{run_name}.tar.gz"
-        _tar_dir(run_dir, tar_path)
-        return tar_path.read_bytes()
-
-
-# -------------------------
-# Local entrypoint
-# -------------------------
 @app.local_entrypoint()
-def submit_ppiflow(
-    # ---------- common ----------
-    task: str = "binder",
-    run_name: str = "test1",
-    out_dir: str = "./ppiflow_outputs",
-    # ---------- local input files ----------
-    binder_input_pdb: str | None = None,
-    ab_antigen_pdb: str | None = None,
-    ab_framework_pdb: str | None = None,
-    pf_complex_pdb: str | None = None,
-    scaffold_motif_csv: str | None = None,
-    # ---------- model weights (sampling tasks only) ----------
-    model_weights: str | None = None,
-    # ---------- config ----------
-    config: str | None = None,
-    # ---------- binder args ----------
-    binder_target_chain: str = "B",
-    binder_binder_chain: str = "A",
-    binder_specified_hotspots: str | None = None,
-    binder_samples_min_length: int = 75,
-    binder_samples_max_length: int = 76,
-    binder_samples_per_target: int = 5,
-    # ---------- antibody/nanobody args ----------
-    ab_antigen_chain: str | None = None,
-    ab_heavy_chain: str | None = None,
-    ab_light_chain: str | None = None,
-    ab_specified_hotspots: str | None = None,
-    ab_cdr_length: str | None = None,
-    ab_samples_per_target: int = 5,
-    # ---------- monomer unconditional ----------
-    mono_length_subset: str | None = None,
-    mono_samples_num: int = 5,
-    # ---------- scaffolding ----------
-    scaffold_motif_names: str | None = None,
-    scaffold_samples_num: int = 5,
-    # ---------- partial flow antibody/nanobody ----------
-    pf_fixed_positions: str | None = None,
-    pf_cdr_position: str | None = None,
-    pf_specified_hotspots: str | None = None,
-    pf_start_t: float | None = None,
-    pf_samples_per_target: int | None = None,
-    pf_retry_limit: int = 10,
-    pf_antigen_chain: str | None = None,
-    pf_heavy_chain: str | None = None,
-    pf_light_chain: str | None = None,
-    # ---------- partial flow binder ----------
-    bpf_target_chain: str = "B",
-    bpf_binder_chain: str = "A",
-    bpf_start_t: float = 0.7,
-    # ---------- mpnn ----------
-    mpnn_source_task: str | None = None,
-    mpnn_source_run: str | None = None,
-    mpnn_num_seq_per_target_stage1: int = 8,
-    mpnn_num_seq_per_target_stage2: int = 4,
-    mpnn_temp_stage1: float = 0.5,
-    mpnn_temp_stage2: float = 0.1,
-    mpnn_model_name: str = "v_48_020",
-    mpnn_batch_size: int = 1,
-    mpnn_seed: int = 0,
-    mpnn_ckpt_path: str | None = None,
-    mpnn_chain_list: str | None = None,
-    mpnn_position_list: str | None = None,
-    mpnn_omit_aas: str | None = None,
-    mpnn_use_soluble_model: bool = False,
+def submit_ppiflow_workflow(
+    run_name: str,
+    ppiflow_args_json: str,
+    ligandmpnn_input_pdb: str,
+    flowpacker_input_pdb: str,
+    rosetta_input_pdb: str,
+    rosetta_script: str,
+    af3_paths_json: str,
+    max_workers: int = 4,
 ) -> None:
-    """Unified Modal CLI.
+    """Execute a queued PPIFlow workflow.
 
-    - Sampling tasks upload inputs (role-based).
-    - MPNN tasks do NOT upload inputs; they operate on an existing run:
-        --mpnn-source-task <task> --mpnn-source-run <run_name>
+    Args:
+        run_name: Stable workflow run identifier.
+        ppiflow_args_json: JSON payload compatible with ``PPIFlowArgs`` model.
+        ligandmpnn_input_pdb: Path to input pdb for LigandMPNN.
+        flowpacker_input_pdb: Path to input pdb for FlowPacker.
+        rosetta_input_pdb: Path to input pdb for Rosetta.
+        rosetta_script: Path to RosettaScript XML file.
+        af3_paths_json: JSON dict with ``run_root/inputs_dir/output_dir/failed_dir/metrics_csv``.
+        max_workers: Number of parallel local orchestration workers.
     """
-    allowed = set(TASK_TO_SCRIPT) | set(MPNN_TASKS)
-    if task not in allowed:
-        raise ValueError(f"--task must be one of {sorted(allowed)}")
+    run_stamp = int(time.time())
+    ligand_bytes = Path(ligandmpnn_input_pdb).expanduser().resolve().read_bytes()
+    flowpacker_bytes = Path(flowpacker_input_pdb).expanduser().resolve().read_bytes()
+    ppiflow_args = json.loads(ppiflow_args_json)
 
-    def _read_file_as(role_name: str, path: str | None) -> tuple[str, bytes] | None:
-        if not path:
-            return None
-        pp = Path(path).expanduser()
-        if not pp.exists():
-            raise FileNotFoundError(f"Local file not found: {pp}")
-        return (role_name, pp.read_bytes())
+    rosetta_run_id = f"{run_name}-{run_stamp}"
 
-    input_files: list[tuple[str, bytes]] = []
+    tasks = [
+        WorkflowTask(
+            task_id="ppiflow_design",
+            app_key="ppiflow",
+            fn_name="ppiflow_run",
+            kwargs={"args": ppiflow_args, "run_name": f"{run_name}-ppiflow"},
+        ),
+        WorkflowTask(
+            task_id="ligandmpnn_sequences",
+            app_key="ligandmpnn",
+            fn_name="ligandmpnn_run",
+            kwargs={
+                "run_name": f"{run_name}-ligandmpnn",
+                "script_mode": "run",
+                "struct_bytes": ligand_bytes,
+                "seeds": [0, 1, 2],
+                "cli_args": {"--verbose": True},
+            },
+            needs={"ppiflow_design"},
+        ),
+        WorkflowTask(
+            task_id="flowpacker_pack",
+            app_key="flowpacker",
+            fn_name="run_flowpacker",
+            kwargs={
+                "input_files": [(Path(flowpacker_input_pdb).name, flowpacker_bytes)],
+                "run_name": f"{run_name}-flowpacker",
+                "n_samples": 1,
+            },
+            needs={"ppiflow_design"},
+        ),
+        WorkflowTask(
+            task_id="rosetta_refine",
+            app_key="rosetta",
+            fn_name="run_rosetta",
+            kwargs={
+                "run_name": run_name,
+                "run_id": rosetta_run_id,
+                "num_cpu_per_pod": 1,
+            },
+            needs={"ppiflow_design"},
+        ),
+        WorkflowTask(
+            task_id="af3_score",
+            app_key="af3score",
+            fn_name="af3score_postprocess",
+            kwargs={
+                "input_files": [Path(flowpacker_input_pdb).name],
+                "paths": json.loads(af3_paths_json),
+            },
+            needs={"ligandmpnn_sequences", "flowpacker_pack", "rosetta_refine"},
+        ),
+    ]
 
-    # Build uploads only for sampling tasks
-    if task in TASK_TO_SCRIPT:
-        if task in {"binder", "binder_partial_flow"}:
-            if not binder_input_pdb:
-                raise ValueError(f"{task} requires --binder-input-pdb")
-            item = _read_file_as("binder_input.pdb", binder_input_pdb)
-            if item:
-                input_files.append(item)
-
-        if task in {"antibody", "nanobody"}:
-            if not ab_antigen_pdb or not ab_framework_pdb:
-                raise ValueError(
-                    f"{task} requires --ab-antigen-pdb and --ab-framework-pdb"
-                )
-            input_files.append(_read_file_as("antigen.pdb", ab_antigen_pdb))
-            input_files.append(_read_file_as("framework.pdb", ab_framework_pdb))
-
-        if task in {"ab_partial_flow", "nb_partial_flow"}:
-            if not pf_complex_pdb:
-                raise ValueError(f"{task} requires --pf-complex-pdb")
-            input_files.append(_read_file_as("complex.pdb", pf_complex_pdb))
-
-        if task == "scaffolding":
-            if not scaffold_motif_csv:
-                raise ValueError("scaffolding requires --scaffold-motif-csv")
-
-            csv_path = Path(scaffold_motif_csv).expanduser()
-            if not csv_path.exists():
-                raise FileNotFoundError(f"Local file not found: {csv_path}")
-
-            csv_text = csv_path.read_text(encoding="utf-8-sig")
-            reader = csv.DictReader(StringIO(csv_text))
-            required_cols = {"target", "length", "contig", "motif_path"}
-            if not reader.fieldnames or not required_cols.issubset(
-                set(reader.fieldnames)
-            ):
-                raise ValueError(
-                    f"motif.csv must have columns {sorted(required_cols)}, got {reader.fieldnames}"
-                )
-
-            rows = list(reader)
-            if not rows:
-                raise ValueError("motif.csv has no data rows")
-
-            csv_dir = csv_path.parent
-            motif_files: dict[str, Path] = {}
-            for r in rows:
-                mp = (r.get("motif_path") or "").strip()
-                if not mp:
-                    raise ValueError(f"motif_path is empty in row: {r}")
-
-                mp_path = Path(mp).expanduser() if mp.startswith("~") else Path(mp)
-                if not mp_path.is_absolute():
-                    mp_path = (csv_dir / mp_path).resolve()
-                if not mp_path.exists():
-                    raise FileNotFoundError(
-                        f"motif_path file not found: {mp_path} (from motif_path={mp!r})"
-                    )
-
-                stable_name = mp_path.name
-                if stable_name in motif_files and motif_files[stable_name] != mp_path:
-                    stable_name = (
-                        f"{mp_path.stem}.{len(motif_files) + 1}{mp_path.suffix}"
-                    )
-                motif_files[stable_name] = mp_path
-                r["motif_path"] = stable_name
-
-            out_buf = StringIO()
-            writer = csv.DictWriter(out_buf, fieldnames=reader.fieldnames)
-            writer.writeheader()
-            writer.writerows(rows)
-            input_files.append(("motif.csv", out_buf.getvalue().encode("utf-8")))
-
-            for stable_name, p in motif_files.items():
-                input_files.append((stable_name, p.read_bytes()))
-
-        if task == "scaffolding" and scaffold_motif_names:
-            s = scaffold_motif_names.strip()
-            if not s.startswith("["):
-                scaffold_motif_names = json.dumps([s])
-    elif task in MPNN_TASKS:
-        if mpnn_position_list and not mpnn_chain_list:
-            raise ValueError(
-                f"{task} requires --mpnn-chain-list when --mpnn-position-list is provided"
-            )
-        if mpnn_position_list:
-            pos_csv = Path(mpnn_position_list).expanduser()
-            if not pos_csv.exists():
-                raise FileNotFoundError(f"Local file not found: {pos_csv}")
-            normalized = _normalize_fixed_positions_csv_bytes(pos_csv.read_bytes())
-            input_files.append(("mpnn_fixed_positions.csv", normalized))
-
-    # dispatch
-    tar_bytes = run_ppiflow_structured.remote(
-        task=task,
-        run_name=run_name,
-        input_files=input_files,
-        model_weights=model_weights,
-        config=config,
-        binder_target_chain=binder_target_chain,
-        binder_binder_chain=binder_binder_chain,
-        binder_specified_hotspots=binder_specified_hotspots,
-        binder_samples_min_length=binder_samples_min_length,
-        binder_samples_max_length=binder_samples_max_length,
-        binder_samples_per_target=binder_samples_per_target,
-        ab_antigen_chain=ab_antigen_chain,
-        ab_heavy_chain=ab_heavy_chain,
-        ab_light_chain=ab_light_chain,
-        ab_specified_hotspots=ab_specified_hotspots,
-        ab_cdr_length=ab_cdr_length,
-        ab_samples_per_target=ab_samples_per_target,
-        mono_length_subset=mono_length_subset,
-        mono_samples_num=mono_samples_num,
-        scaffold_motif_names=scaffold_motif_names,
-        scaffold_samples_num=scaffold_samples_num,
-        pf_fixed_positions=pf_fixed_positions,
-        pf_cdr_position=pf_cdr_position,
-        pf_specified_hotspots=pf_specified_hotspots,
-        pf_start_t=pf_start_t,
-        pf_samples_per_target=pf_samples_per_target,
-        pf_retry_limit=pf_retry_limit,
-        pf_antigen_chain=pf_antigen_chain,
-        pf_heavy_chain=pf_heavy_chain,
-        pf_light_chain=pf_light_chain,
-        bpf_target_chain=bpf_target_chain,
-        bpf_binder_chain=bpf_binder_chain,
-        bpf_start_t=bpf_start_t,
-        mpnn_source_task=mpnn_source_task,
-        mpnn_source_run=mpnn_source_run,
-        mpnn_num_seq_per_target_stage1=mpnn_num_seq_per_target_stage1,
-        mpnn_num_seq_per_target_stage2=mpnn_num_seq_per_target_stage2,
-        mpnn_temp_stage1=mpnn_temp_stage1,
-        mpnn_temp_stage2=mpnn_temp_stage2,
-        mpnn_batch_size=mpnn_batch_size,
-        mpnn_seed=mpnn_seed,
-        mpnn_ckpt_path=mpnn_ckpt_path,
-        mpnn_model_name=mpnn_model_name,
-        mpnn_chain_list=mpnn_chain_list,
-        mpnn_omit_aas=mpnn_omit_aas,
-        mpnn_use_soluble_model=mpnn_use_soluble_model,
-    )
-
-    out_dir_p = Path(out_dir).expanduser()
-    out_dir_p.mkdir(parents=True, exist_ok=True)
-    out_tar = out_dir_p / f"{task}.{run_name}.tar.gz"
-    out_tar.write_bytes(tar_bytes)
-    print(f"[ok] saved: {out_tar}")
+    results = _schedule(tasks=tasks, max_workers=max_workers)
+    print("🧬 Workflow completed. Task outputs:")
+    for task_id, result in results.items():
+        print(f"  - {task_id}: {type(result).__name__}")


### PR DESCRIPTION
### Motivation
- Provide a lightweight Modal task orchestrator that reproduces the PPIFlow multi-stage workflow while calling already-deployed app functions and enabling parallel execution of independent stages.
- Replace the previous monolithic workflow implementation with a dependency-aware scheduler to simplify orchestration, improve concurrency, and make the pipeline easier to reuse across deployed Modal apps.

### Description
- Replaced the contents of `src/biomodals/workflow/ppiflow_workflow.py` with a new dependency-aware orchestrator centered on a `WorkflowTask` dataclass. 
- Added `_lookup_function` and `_run_task` helpers which invoke deployed functions via `modal.Function.lookup(...).remote(...)` and implemented `_schedule`, a scheduler that runs independent tasks concurrently using `ThreadPoolExecutor`. 
- Added a local entrypoint `submit_ppiflow_workflow(...)` that builds a DAG and dispatches the stages `ppiflow_run` (PPIFlow), `ligandmpnn_run` (LigandMPNN), `run_flowpacker` (FlowPacker), `run_rosetta` (Rosetta), and `af3score_postprocess` (AF3Score) with the intended dependencies and parallelization. 
- Introduced a `DEFAULT_APP_NAMES` mapping for logical app keys and did not modify any existing app modules; the orchestrator assumes the corresponding Modal functions are deployed and available under those app names.

### Testing
- Ran `python -m py_compile src/biomodals/workflow/ppiflow_workflow.py` which succeeded. 
- Attempted `uv run prek run --files src/biomodals/workflow/ppiflow_workflow.py` but the run failed due to package index/network access issues in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ca89666c83269f3dbf184d048d06)